### PR TITLE
dplyr 1.2.0 revdep failures

### DIFF
--- a/R/plot_pie.R
+++ b/R/plot_pie.R
@@ -119,11 +119,12 @@ plot_pie <- function(data,
     dplyr::arrange(dplyr::desc(count)) |>
     dplyr::mutate(
       percent = round(count / total * 100, 1),
-      label_text = dplyr::case_when(
-        label == "count"   ~ as.character(count),
-        label == "percent" ~ paste0(percent, "%"),
-        label == "both"    ~ paste0(count, " (", percent, "%)"),
-        TRUE               ~ ""
+      label_text = switch(
+        label,
+        "count" = as.character(count),
+        "percent" = paste0(percent, "%"),
+        "both" = paste0(count, " (", percent, "%)"),
+        ""
       )
     )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -240,6 +240,6 @@ palette_cache_info <- function() {
 utils::globalVariables(
   c(
     "x", "y", "color", "group", "name", "label_text", "count",
-    "symbol", "entrez_id", "gene", "current_release"
+    "symbol", "entrez_id", "gene", "current_release", "percent"
   )
 )


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

`case_when()` now warns when a simple if/else of switch would have sufficed. This has caused a failure in your tests.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!